### PR TITLE
Add a version check for LambdaStaticData/LambdaInfo

### DIFF
--- a/src/twtree.jl
+++ b/src/twtree.jl
@@ -19,7 +19,7 @@ moduleallnames = Dict{ Module, Array{ Symbol, 1 } }()
 typefields  = Dict{ Any, Array{ Symbol, 1 } }()
 
 typefields[ Method ] = [ :sig, :isstaged ]
-typefields[ LambdaInfo ] = [ :name, :module, :file, :line ]
+typefields[ VERSION < v"0.5-" ? LambdaStaticData : LambdaInfo ] = [ :name, :module, :file, :line ]
 typefields[ DataType ] = [ :name, :super, Symbol( "abstract" ), :mutable, :parameters ]
 typefields[ TypeName ] = [ :name, :module, :primary ]
 


### PR DESCRIPTION
Provides backwards compatibility for Julia 0.4 and earlier