### PR TITLE
Fall back to wide-char versions of lib{ncurses,panel} on load failure

### DIFF
--- a/src/TermWin.jl
+++ b/src/TermWin.jl
@@ -120,16 +120,16 @@ function initsession()
             throw( "terminal doesn't support colors")
         end
         mousemask( BUTTON1_PRESSED | REPORT_MOUSE_POSITION )
-        acs_map_ptr = cglobal( (:acs_map, :libncurses ), UInt32 )
+        acs_map_ptr = cglobal( Libdl.dlsym( libncurses, :acs_map), UInt32 )
         acs_map_arr = pointer_to_array( acs_map_ptr, 128)
 
         start_color()
         # figure out how many colors are supported
-        colorsptr = cglobal( (:COLORS, :libncurses ), Int16 )
+        colorsptr = cglobal( Libdl.dlsym( libncurses, :COLORS), Int16 )
         colorsarr = pointer_to_array( colorsptr, 1 )
         COLORS = colorsarr[1]
 
-        colorsptr = cglobal( (:COLOR_PAIRS, :libncurses ), Int16 )
+        colorsptr = cglobal( Libdl.dlsym( libncurses, :COLOR_PAIRS), Int16 )
         colorsarr = pointer_to_array( colorsptr, 1 )
         COLOR_PAIRS = colorsarr[1]
 

--- a/src/ccall.jl
+++ b/src/ccall.jl
@@ -6,8 +6,16 @@ libpanel = false
 function initscr()
     global libncurses, libpanel
     if  libncurses == false
-        libncurses = Libdl.dlopen("libncurses")
-        libpanel = Libdl.dlopen("libpanel")
+        try
+            libncurses = Libdl.dlopen("libncurses")
+        catch
+            libncurses = Libdl.dlopen("libncursesw")
+        end
+        try
+            libpanel = Libdl.dlopen("libpanel")
+        catch
+            libpanel = Libdl.dlopen("libpanelw")
+        end
     end
     ccall( Libdl.dlsym( libncurses, :initscr), Ptr{Void}, () )
 end


### PR DESCRIPTION
On some systems, libncurses.so and libpanel.so are linker scripts
rather than actual binaries. Trying to load these libraries in
Julia produces errors, as Julia currently doesn't know how to handle
such linker scripts,

Work around this issue by trying the most common redirections
specified by linker scripts:

libncurses.so -> libncursesw.so
libpanel.so -> libpanelw.so